### PR TITLE
bugfix: restored API to Fake for Speaker, corrected reload_on_error

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -53,7 +53,7 @@ class ECellApp extends StatelessWidget {
           S.routeHome: (_) =>
               BlocProvider(create: (_) => FeedbackCubit(APIHomeRepository()), child: HomeScreen()),
           S.routeSpeaker: (_) => BlocProvider(
-              create: (_) => SpeakerCubit(APISpeakerRepository()), child: SpeakerScreen()),
+              create: (_) => SpeakerCubit(FakeSpeakerRepository()), child: SpeakerScreen()),
           S.routeEvents: (_) => BlocProvider(
               create: (_) => EventsCubit(APIEventsRepository()), child: EventsScreen()),
           S.routeSponsors: (_) => BlocProvider(

--- a/lib/screens/events/events.dart
+++ b/lib/screens/events/events.dart
@@ -14,50 +14,40 @@ import 'events_card.dart';
 class EventsScreen extends StatelessWidget {
   const EventsScreen({Key key}) : super(key: key);
 
-  _doReaload(BuildContext context) {
-    //TODO:
-  }
   @override
   Widget build(BuildContext context) {
     return StatefulWrapper(
       onInit: () => _getAllEvents(context),
       child: Scaffold(
-        body: BlocConsumer<EventsCubit, EventsState>(
-          listener: (context, state) {
-            if (state is EventsError) {
-              Scaffold.of(context).showSnackBar(SnackBar(content: Text(state.message)));
-            }
-          },
-          builder: (context, state) {
-            return Scaffold(
-              resizeToAvoidBottomInset: false,
-              extendBodyBehindAppBar: true,
-              appBar: AppBar(
-                elevation: 0,
-                backgroundColor: Colors.transparent,
-                leading: Container(
-                  padding: EdgeInsets.only(left: D.horizontalPadding - 10, top: 10),
-                  child: IconButton(
-                    icon: Icon(Icons.arrow_back_ios, color: Colors.white, size: 30),
-                    onPressed: () => Navigator.of(context).pop(),
-                  ),
-                ),
-              ),
-              body: Stack(
-                children: [
-                  ScreenBackground(elementId: 0),
-                  if (state is EventsInitial)
-                    _buildLoading(context)
-                  else if (state is EventsSuccess)
-                    _buildSuccess(context, state.json)
-                  else if (state is EventsLoading)
-                    _buildLoading(context)
-                  else
-                    ReloadOnErrorScreen(doOnPress: () => _doReaload(context)),
-                ],
-              ),
-            );
-          },
+        resizeToAvoidBottomInset: false,
+        extendBodyBehindAppBar: true,
+        appBar: AppBar(
+          elevation: 0,
+          backgroundColor: Colors.transparent,
+          leading: Container(
+            padding: EdgeInsets.only(left: D.horizontalPadding - 10, top: 10),
+            child: IconButton(
+              icon: Icon(Icons.arrow_back_ios, color: Colors.white, size: 30),
+              onPressed: () => Navigator.of(context).pop(),
+            ),
+          ),
+        ),
+        body: Stack(
+          children: [
+            ScreenBackground(elementId: 0),
+            BlocBuilder<EventsCubit, EventsState>(
+              builder: (context, state) {
+                if (state is EventsInitial)
+                  return _buildLoading(context);
+                else if (state is EventsSuccess)
+                  return _buildSuccess(context, state.json);
+                else if (state is EventsLoading)
+                  return _buildLoading(context);
+                else
+                  return ReloadOnErrorWidget(() => _getAllEvents(context));
+              },
+            ),
+          ],
         ),
       ),
     );

--- a/lib/screens/speaker/speaker.dart
+++ b/lib/screens/speaker/speaker.dart
@@ -15,56 +15,44 @@ class SpeakerScreen extends StatelessWidget {
 
   final ScrollController _scrollController = ScrollController();
 
-  _doReaload(BuildContext context) {
-    //TODO: Resolve _getAllSpeakers(context); not working
-  }
-
   @override
   Widget build(BuildContext context) {
     return StatefulWrapper(
       onInit: () => _getAllSpeakers(context),
       child: Scaffold(
-        body: BlocConsumer<SpeakerCubit, SpeakerState>(
-          listener: (context, state) {
-            if (state is SpeakerError) {
-              Scaffold.of(context).showSnackBar(SnackBar(content: Text(state.message)));
-            }
-          },
-          builder: (context, state) {
-            return Scaffold(
-                extendBodyBehindAppBar: true,
-                backgroundColor: Colors.transparent,
-                appBar: AppBar(
-                  elevation: 0,
-                  backgroundColor: Colors.transparent,
-                  leading: Container(
-                    padding: EdgeInsets.all(D.horizontalPadding - 10),
-                    child: IconButton(
-                      icon: Icon(Icons.arrow_back_ios, color: Colors.white, size: 30),
-                      onPressed: () => Navigator.of(context).pop(),
-                    ),
-                  ),
-                ),
-                body: Container(
-                  decoration: BoxDecoration(
-                    gradient: LinearGradient(
-                      begin: Alignment.topCenter,
-                      end: Alignment.bottomCenter,
-                      colors: [C.backgroundTop1, C.backgroundBottom1],
-                    ),
-                  ),
-                  child: () {
-                    if (state is SpeakerInitial)
-                      return _buildLoading(context);
-                    else if (state is SpeakerSuccess)
-                      return _buildSuccess(context, state.speakerList);
-                    else if (state is SpeakerLoading)
-                      return _buildLoading(context);
-                    else
-                      return ReloadOnErrorScreen(doOnPress: () => _doReaload(context));
-                  }(),
-                ));
-          },
+        extendBodyBehindAppBar: true,
+        backgroundColor: Colors.transparent,
+        appBar: AppBar(
+          elevation: 0,
+          backgroundColor: Colors.transparent,
+          leading: Container(
+            padding: EdgeInsets.only(left: D.horizontalPadding - 10),
+            child: IconButton(
+              icon: Icon(Icons.arrow_back_ios, color: Colors.white, size: 30),
+              onPressed: () => Navigator.of(context).pop(),
+            ),
+          ),
+        ),
+        body: Container(
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              begin: Alignment.topCenter,
+              end: Alignment.bottomCenter,
+              colors: [C.backgroundTop1, C.backgroundBottom1],
+            ),
+          ),
+          child: BlocBuilder<SpeakerCubit, SpeakerState>(
+            builder: (context, state) {
+              if (state is SpeakerInitial)
+                return _buildLoading(context);
+              else if (state is SpeakerSuccess)
+                return _buildSuccess(context, state.speakerList);
+              else if (state is SpeakerLoading)
+                return _buildLoading(context);
+              else
+                return ReloadOnErrorWidget(() => _getAllSpeakers(context));
+            },
+          ),
         ),
       ),
     );
@@ -73,13 +61,14 @@ class SpeakerScreen extends StatelessWidget {
   Widget _buildSuccess(BuildContext context, List<Speaker> speakerList) {
     double height = MediaQuery.of(context).size.height;
     double bottom = MediaQuery.of(context).viewInsets.bottom;
-    double top = MediaQuery.of(context).viewPadding.top;
+    double top = MediaQuery.of(context).viewInsets.top;
     double ratio = MediaQuery.of(context).size.aspectRatio;
 
     List<Widget> speakerContentList = [];
     speakerList.forEach((element) => speakerContentList.add(SpeakerCard(speaker: element)));
 
     if (_scrollController.hasClients) {
+      // TODO verify the use of this controller
       if (bottom > height * 0.25) {
         _scrollController.animateTo(
           bottom - height * 0.25,
@@ -101,10 +90,9 @@ class SpeakerScreen extends StatelessWidget {
         child: SingleChildScrollView(
           scrollDirection: Axis.vertical,
           controller: _scrollController,
-          child: Container(
-            margin: EdgeInsets.only(top: top + 56),
+          child: Padding(
+            padding: EdgeInsets.only(top: top + 56),
             child: Column(
-              mainAxisSize: MainAxisSize.min,
               children: <Widget>[
                 Text(
                   "Speakers",

--- a/lib/screens/speaker/speaker_repository.dart
+++ b/lib/screens/speaker/speaker_repository.dart
@@ -23,7 +23,7 @@ class FakeSpeakerRepository extends SpeakerRepository {
     await Future.delayed(Duration(seconds: 1));
 
     //Fake Response and Network Delay
-    if (true || Random().nextBool()) {
+    if (Random().nextBool()) {
       throw NetworkException();
     } else {
       var response = {
@@ -167,11 +167,7 @@ class FakeSpeakerRepository extends SpeakerRepository {
         "message": "Speakers Fetched Successfully"
       };
 
-      List<Speaker> speakerList = List();
-
-      (response["data"] as List).map((e) => speakerList.add(Speaker.fromJson(e))).toList();
-
-      return speakerList;
+      return (response["data"] as List).map((e) => Speaker.fromJson(e)).toList();
     }
   }
 }
@@ -190,9 +186,7 @@ class APISpeakerRepository extends SpeakerRepository {
 
     if (response.statusCode == 200) {
       var speakerResponse = jsonDecode(response.body);
-      List<Speaker> speakerList;
-      (speakerResponse["data"] as List).forEach((e) => speakerList.add(Speaker.fromJson(e)));
-      return speakerList;
+      return (speakerResponse["data"] as List).map((e) => Speaker.fromJson(e)).toList();
     } else if (response.statusCode == 404) {
       throw ValidationException(response.body);
     } else {

--- a/lib/screens/sponsors/sponsors.dart
+++ b/lib/screens/sponsors/sponsors.dart
@@ -10,41 +10,35 @@ import 'cubit/sponsors_cubit.dart';
 class SponsorsScreen extends StatelessWidget {
   const SponsorsScreen({Key key}) : super(key: key);
 
-  _doReaload(BuildContext context) {
-    //TODO:
-  }
-
   @override
   Widget build(BuildContext context) {
     return StatefulWrapper(
-      onInit: () => _getAllSponsorss(context),
+      onInit: () => _getAllSponsors(context),
       child: Scaffold(
-        body: BlocConsumer<SponsorsCubit, SponsorsState>(listener: (context, state) {
-          if (state is SponsorsError) {
-            Scaffold.of(context).showSnackBar(SnackBar(content: Text(state.message)));
-          }
-        }, builder: (context, state) {
-          return Stack(
-            children: [
-              ScreenBackground(elementId: 0),
-              if (state is SponsorsInitial)
-                _buildLoading(context)
-              else if (state is SponsorsSuccess)
-                _buildSuccess(context, state.sponsorsList)
-              else if (state is SponsorsLoading)
-                _buildLoading(context)
-              else
-                ReloadOnErrorScreen(doOnPress: () => _doReaload(context)),
-            ],
-          );
-        }),
+        body: Stack(
+          children: [
+            ScreenBackground(elementId: 0),
+            BlocBuilder<SponsorsCubit, SponsorsState>(
+              builder: (context, state) {
+                if (state is SponsorsInitial)
+                  return _buildLoading(context);
+                else if (state is SponsorsSuccess)
+                  return _buildSuccess(context, state.sponsorsList);
+                else if (state is SponsorsLoading)
+                  return _buildLoading(context);
+                else
+                  return ReloadOnErrorWidget(() => _getAllSponsors(context));
+              },
+            ),
+          ],
+        ),
       ),
     );
   }
 
   Widget _buildSuccess(BuildContext context, List<SponsorCategory> sponsorsList) {
     //TODO: UI
-    List<Widget> sL = [];
+    List<Widget> sL = [Text("Sponsors")];
     for (var item in sponsorsList) {
       sL.add(Text(item.category, textAlign: TextAlign.center));
     }
@@ -61,7 +55,7 @@ class SponsorsScreen extends StatelessWidget {
     return Center(child: ECellLogoAnimation(size: width / 2));
   }
 
-  void _getAllSponsorss(BuildContext context) {
+  void _getAllSponsors(BuildContext context) {
     final cubit = context.read<SponsorsCubit>();
     cubit.getSponsorsList();
   }

--- a/lib/widgets/reload_on_error.dart
+++ b/lib/widgets/reload_on_error.dart
@@ -4,13 +4,10 @@ import 'package:google_fonts/google_fonts.dart';
 import 'package:ecellapp/core/res/colors.dart';
 import 'package:ecellapp/core/res/strings.dart';
 
-class ReloadOnErrorScreen extends StatelessWidget {
-  final Function doOnPress;
+class ReloadOnErrorWidget extends StatelessWidget {
+  final Function onReload;
 
-  const ReloadOnErrorScreen({
-    Key key,
-    this.doOnPress,
-  }) : super(key: key);
+  const ReloadOnErrorWidget(this.onReload);
 
   @override
   Widget build(BuildContext context) {
@@ -60,7 +57,7 @@ class ReloadOnErrorScreen extends StatelessWidget {
                           borderRadius: BorderRadius.all(Radius.circular(30)),
                         ),
                         color: C.authButtonColor,
-                        onPressed: () => {doOnPress},
+                        onPressed: onReload,
                         child: Container(
                           height: ratio > 0.5 ? 40 : 60,
                           width: ratio > 0.5 ? 80 : 100,


### PR DESCRIPTION
DONE:
1. Previously, you had implemented map incorrectly. Maybe I didn't review it throughly, but you should not make such mistakes. Please check the changes, read more about map and forEach. If you still have doubt, let me know.

2. Since we have handled Error states in builder itself, there is no need for listener in some screens (Events, Sponsors, Speakers) Replaced BlocConsumer with BlocBuilder because listener is of no use anymore


Potential Bugs / Redundant code:
1. Use of scroll controller in events and speaker.